### PR TITLE
[spec] use a temporary mermaid patch

### DIFF
--- a/tech-specs/Makefile
+++ b/tech-specs/Makefile
@@ -8,6 +8,8 @@ serve:
 
 dev-deps:
 	$(cargo) install mdbook
-	$(cargo) install mdbook-mermaid
+	$(cargo) install mdbook-mermaid \
+		--git https://github.com/eminence/mdbook-mermaid --branch bump_mdbook --rev 4f33cfa917832b21477e858380cdff2ace61baf3
+    # TODO ^ temporary until https://github.com/badboy/mdbook-mermaid/pull/11 is merged and released
 
 .PHONY: build serve


### PR DESCRIPTION
The spec is still failing the deploy, it's a bug in the mermaid plugin which is incompatible with a newer version of mdbook described here: https://github.com/badboy/mdbook-mermaid/pull/11

I'm changing the installation command to get the plugin from this commit until it's merged and released.

Failing job: https://github.com/anomanetwork/anoma/runs/2771610663?check_suite_focus=true#step:5:711