### PR TITLE
use new tendermint-rs branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4242,7 +4242,7 @@ dependencies = [
 [[package]]
 name = "tendermint"
 version = "0.19.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/update-tendermint-config#83d282470280588dbe3479ec1c3c0b3552e625c7"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/config-opt-values#eacdc2a0e4547f55af22870188a2ce0149feafa2"
 dependencies = [
  "anomaly",
  "async-trait",
@@ -4273,7 +4273,7 @@ dependencies = [
 [[package]]
 name = "tendermint-abci"
 version = "0.19.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/update-tendermint-config#83d282470280588dbe3479ec1c3c0b3552e625c7"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/config-opt-values#eacdc2a0e4547f55af22870188a2ce0149feafa2"
 dependencies = [
  "bytes 1.0.1",
  "eyre",
@@ -4286,7 +4286,7 @@ dependencies = [
 [[package]]
 name = "tendermint-proto"
 version = "0.19.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/update-tendermint-config#83d282470280588dbe3479ec1c3c0b3552e625c7"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/config-opt-values#eacdc2a0e4547f55af22870188a2ce0149feafa2"
 dependencies = [
  "anomaly",
  "bytes 1.0.1",
@@ -4304,7 +4304,7 @@ dependencies = [
 [[package]]
 name = "tendermint-rpc"
 version = "0.19.0"
-source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/update-tendermint-config#83d282470280588dbe3479ec1c3c0b3552e625c7"
+source = "git+https://github.com/heliaxdev/tendermint-rs?branch=tomas/config-opt-values#eacdc2a0e4547f55af22870188a2ce0149feafa2"
 dependencies = [
  "async-trait",
  "bytes 1.0.1",

--- a/apps/Cargo.toml
+++ b/apps/Cargo.toml
@@ -69,11 +69,11 @@ serde_regex = "1.1.0"
 sha2 = "0.9.3"
 signal-hook = "0.3.9"
 sparse-merkle-tree = {git = "https://github.com/heliaxdev/sparse-merkle-tree", branch = "tomas/encoding-0.9.0b", features = ["borsh"]}
-# temporarily using fork work-around for https://github.com/informalsystems/tendermint-rs/issues/876 and https://github.com/informalsystems/tendermint-rs/issues/896
-tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/update-tendermint-config"}
-tendermint-abci = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/update-tendermint-config"}
-tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/update-tendermint-config"}
-tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/update-tendermint-config", features = ["http-client"]}
+# temporarily using fork work-around for https://github.com/informalsystems/tendermint-rs/issues/876 and, https://github.com/informalsystems/tendermint-rs/issues/896, https://github.com/informalsystems/tendermint-rs/issues/906, https://github.com/informalsystems/tendermint-rs/issues/907
+tendermint = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/config-opt-values"}
+tendermint-abci = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/config-opt-values"}
+tendermint-proto = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/config-opt-values"}
+tendermint-rpc = {git = "https://github.com/heliaxdev/tendermint-rs", branch = "tomas/config-opt-values", features = ["http-client"]}
 thiserror = "1.0.24"
 tokio = {version = "1.2.0", features = ["full"]}
 toml = "0.5.8"


### PR DESCRIPTION
The new branch contains fixes for https://github.com/informalsystems/tendermint-rs/issues/906 and https://github.com/informalsystems/tendermint-rs/issues/907, which caused a bug in the config parser and serialization. Running `make run-ledger`, shut it down and run `make run-ledger` again would crash with config parsing issue.