### PR TITLE
Added the --all-targets flag to clippy linting

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ kind: pipeline
 name: anoma-ci-build-pr
 node: {project: anoma}
 steps:
-- commands: [echo "5f49930241fc317b8c1efb460b2411b39fb6e9fbf5bb526c230b3b848bd76686  Makefile"
+- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -110,7 +110,7 @@ kind: pipeline
 name: anoma-ci-checks-pr
 node: {project: anoma}
 steps:
-- commands: [echo "5f49930241fc317b8c1efb460b2411b39fb6e9fbf5bb526c230b3b848bd76686  Makefile"
+- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -197,7 +197,7 @@ kind: pipeline
 name: anoma-ci-wasm-pr
 node: {project: anoma}
 steps:
-- commands: [echo "5f49930241fc317b8c1efb460b2411b39fb6e9fbf5bb526c230b3b848bd76686  Makefile"
+- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -280,7 +280,7 @@ kind: pipeline
 name: anoma-ci-audit-pr
 node: {project: anoma}
 steps:
-- commands: [echo "5f49930241fc317b8c1efb460b2411b39fb6e9fbf5bb526c230b3b848bd76686  Makefile"
+- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -347,7 +347,7 @@ kind: pipeline
 name: anoma-ci-miri-pr
 node: {project: anoma}
 steps:
-- commands: [echo "5f49930241fc317b8c1efb460b2411b39fb6e9fbf5bb526c230b3b848bd76686  Makefile"
+- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -420,7 +420,7 @@ kind: pipeline
 name: anoma-ci-docs-master
 node: {project: anoma}
 steps:
-- commands: [echo "5f49930241fc317b8c1efb460b2411b39fb6e9fbf5bb526c230b3b848bd76686  Makefile"
+- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -501,7 +501,7 @@ kind: pipeline
 name: anoma-ci-build-master
 node: {project: anoma}
 steps:
-- commands: [echo "5f49930241fc317b8c1efb460b2411b39fb6e9fbf5bb526c230b3b848bd76686  Makefile"
+- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -618,6 +618,6 @@ type: docker
 workspace: {path: /usr/local/rust/project}
 ---
 kind: signature
-hmac: 47de0bc680ef6a770b61f57044b827dcd40f8e813e92d59c679c6a0aa31dbe5d
+hmac: bc68029def99f5bdd86c3432b2d9ab79dc5b00a018a9c229f19186da879ee096
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ kind: pipeline
 name: anoma-ci-build-pr
 node: {project: anoma}
 steps:
-- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
+- commands: [echo "6024944b58a5f176db43ca46247b182774f9601f038fdc3162dc24fe488d3fdd  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -110,7 +110,7 @@ kind: pipeline
 name: anoma-ci-checks-pr
 node: {project: anoma}
 steps:
-- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
+- commands: [echo "6024944b58a5f176db43ca46247b182774f9601f038fdc3162dc24fe488d3fdd  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -142,7 +142,7 @@ steps:
     mount: [.cargo]
     region: eu-west-1
     restore: true
-- commands: [sccache --start-server, make clippy-check]
+- commands: [sccache --start-server, make clippy]
   depends_on: [restore-cache]
   environment:
     AWS_ACCESS_KEY_ID: {from_secret: aws_access_key_id}
@@ -150,7 +150,7 @@ steps:
     SCCACHE_BUCKET: heliax-drone-cache-v2
     SCCACHE_S3_KEY_PREFIX: sccache-check
   image: 965844283396.dkr.ecr.eu-west-1.amazonaws.com/anoma:latest
-  name: clippy-check
+  name: clippy
   pull: if-not-exists
 - commands: [sccache --start-server, make fmt-check]
   depends_on: [restore-cache]
@@ -163,7 +163,7 @@ steps:
   name: fmt-check
   pull: if-not-exists
 - commands: [cargo-cache]
-  depends_on: [clippy-check, fmt-check]
+  depends_on: [clippy, fmt-check]
   image: 965844283396.dkr.ecr.eu-west-1.amazonaws.com/anoma:latest
   name: clean-cache
   pull: if-not-exists
@@ -197,7 +197,7 @@ kind: pipeline
 name: anoma-ci-wasm-pr
 node: {project: anoma}
 steps:
-- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
+- commands: [echo "6024944b58a5f176db43ca46247b182774f9601f038fdc3162dc24fe488d3fdd  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -280,7 +280,7 @@ kind: pipeline
 name: anoma-ci-audit-pr
 node: {project: anoma}
 steps:
-- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
+- commands: [echo "6024944b58a5f176db43ca46247b182774f9601f038fdc3162dc24fe488d3fdd  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -347,7 +347,7 @@ kind: pipeline
 name: anoma-ci-miri-pr
 node: {project: anoma}
 steps:
-- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
+- commands: [echo "6024944b58a5f176db43ca46247b182774f9601f038fdc3162dc24fe488d3fdd  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -420,7 +420,7 @@ kind: pipeline
 name: anoma-ci-docs-master
 node: {project: anoma}
 steps:
-- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
+- commands: [echo "6024944b58a5f176db43ca46247b182774f9601f038fdc3162dc24fe488d3fdd  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -501,7 +501,7 @@ kind: pipeline
 name: anoma-ci-build-master
 node: {project: anoma}
 steps:
-- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
+- commands: [echo "6024944b58a5f176db43ca46247b182774f9601f038fdc3162dc24fe488d3fdd  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -618,6 +618,6 @@ type: docker
 workspace: {path: /usr/local/rust/project}
 ---
 kind: signature
-hmac: 23c0a0c603d2365afed02663cdc886e96e621ddc861bb4a2f013da04f683f677
+hmac: 3cc71ac1cd21252dfce959dc58b66bbf1c341d538d251b5698bdade7483cac3a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ kind: pipeline
 name: anoma-ci-build-pr
 node: {project: anoma}
 steps:
-- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
+- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -110,7 +110,7 @@ kind: pipeline
 name: anoma-ci-checks-pr
 node: {project: anoma}
 steps:
-- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
+- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -197,7 +197,7 @@ kind: pipeline
 name: anoma-ci-wasm-pr
 node: {project: anoma}
 steps:
-- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
+- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -280,7 +280,7 @@ kind: pipeline
 name: anoma-ci-audit-pr
 node: {project: anoma}
 steps:
-- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
+- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -347,7 +347,7 @@ kind: pipeline
 name: anoma-ci-miri-pr
 node: {project: anoma}
 steps:
-- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
+- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -420,7 +420,7 @@ kind: pipeline
 name: anoma-ci-docs-master
 node: {project: anoma}
 steps:
-- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
+- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -501,7 +501,7 @@ kind: pipeline
 name: anoma-ci-build-master
 node: {project: anoma}
 steps:
-- commands: [echo "4d5fe55612210b0859fc9849d45f3e41ffa303c75479ef0348c04712b5b3bf37  Makefile"
+- commands: [echo "3dc207ab7e5835cb11997fc2abd52f707aa4847beab1a83b4f946a418808e287  Makefile"
       | sha256sum -c -, echo "1f936cd80d5361b6e4d38a492133e13c3b80d613fac512d22c574f96b69a9d2a  wasm/vps/vp_template/Makefile"
       | sha256sum -c -, echo "fffb93df6818d9e7afe682bc1120e2068bde6224cb1c77edb3bb2710e3baed81  wasm/vps/vp_token/Makefile"
       | sha256sum -c -, echo "ff903ca4314f5a754ac887fde8c365379e70541c52b07e24e043da3afd54901b  wasm/vps/vp_user/Makefile"
@@ -618,6 +618,6 @@ type: docker
 workspace: {path: /usr/local/rust/project}
 ---
 kind: signature
-hmac: bc68029def99f5bdd86c3432b2d9ab79dc5b00a018a9c229f19186da879ee096
+hmac: 23c0a0c603d2365afed02663cdc886e96e621ddc861bb4a2f013da04f683f677
 
 ...

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ target/
 
 # Crafted data with transaction and intent payloads for testing
 *.data
+
+# generated if using pyenv to manage different python versions
+.python-version
+
+# generated if using IntelliJ IDEs
+/.idea

--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,10 @@ check:
 	$(cargo) check && \
 	$(foreach wasm,$(wasms),$(check-wasm) && ) true
 
-clippy-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml
+clippy-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml --all-targets -- -D warnings
 clippy:
-	$(cargo) +$(nightly) clippy && \
-	$(foreach wasm,$(wasms),$(clippy-wasm) && ) true
-
-clippy-check-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml --all-targets -- -D warnings
-clippy-check:
 	$(cargo) +$(nightly) clippy --all-targets -- -D warnings && \
-	$(foreach wasm,$(wasms),$(clippy-check-wasm) && ) true
+	$(foreach wasm,$(wasms),$(clippy-wasm) && ) true
 
 install:
 	# Warning: built in debug mode for now

--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ clippy:
 	$(cargo) +$(nightly) clippy && \
 	$(foreach wasm,$(wasms),$(clippy-wasm) && ) true
 
-clippy-check-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml -- -D warnings
+clippy-check-wasm = $(cargo) +$(nightly) clippy --manifest-path $(wasm)/Cargo.toml --all-targets -- -D warnings
 clippy-check:
-	$(cargo) +$(nightly) clippy -- -D warnings && \
+	$(cargo) +$(nightly) clippy --all-targets -- -D warnings && \
 	$(foreach wasm,$(wasms),$(clippy-check-wasm) && ) true
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -124,4 +124,4 @@ test-miri:
 	$(cargo) +$(nightly) clean
 	MIRIFLAGS="-Zmiri-disable-isolation" $(cargo) +$(nightly) miri test
 
-.PHONY : build check build-release clippy clippy-check install run-ledger run-gossip reset-ledger test test-debug fmt watch clean build-doc doc build-wasm-scripts-docker build-wasm-scripts clean-wasm-scripts dev-deps test-miri
+.PHONY : build check build-release clippy install run-ledger run-gossip reset-ledger test test-debug fmt watch clean build-doc doc build-wasm-scripts-docker build-wasm-scripts clean-wasm-scripts dev-deps test-miri

--- a/apps/src/lib/config.rs
+++ b/apps/src/lib/config.rs
@@ -306,16 +306,15 @@ impl IntentGossiper {
         let mut gossiper_config = IntentGossiper::default();
         let mut discover_config = DiscoverPeer::default();
 
-        gossiper_config.address = Multiaddr::from_str(
-            &format!("/ip4/{}/tcp/{}", ip, port).to_string(),
-        )
-        .unwrap();
+        gossiper_config.address =
+            Multiaddr::from_str(format!("/ip4/{}/tcp/{}", ip, port).as_str())
+                .unwrap();
 
         let bootstrap_peers: HashSet<PeerAddress> = peers_info
             .iter()
             .map(|info| PeerAddress {
                 address: Multiaddr::from_str(
-                    &format!("/ip4/{}/tcp/{}", info.0, info.1).to_string(),
+                    format!("/ip4/{}/tcp/{}", info.0, info.1).as_str(),
                 )
                 .unwrap(),
                 peer_id: info.2,

--- a/apps/src/lib/proto/types.rs
+++ b/apps/src/lib/proto/types.rs
@@ -134,7 +134,7 @@ mod tests {
         let topic = "arbitrary string".to_owned();
         let topic_message = SubscribeTopicMessage::new(topic.clone());
 
-        let topic_rpc_message = RpcMessage::new_topic(topic.clone());
+        let topic_rpc_message = RpcMessage::new_topic(topic);
         let services_rpc_message: services::RpcMessage =
             topic_rpc_message.into();
         match services_rpc_message.message {

--- a/shared/src/proto/types.rs
+++ b/shared/src/proto/types.rs
@@ -307,7 +307,7 @@ mod tests {
     fn test_intent_gossip_message() {
         let data = "arbitrary data".as_bytes().to_owned();
         let intent = Intent::new(data);
-        let message = IntentGossipMessage::new(intent.clone());
+        let message = IntentGossipMessage::new(intent);
 
         let bytes = message.to_bytes();
         let message_from_bytes = IntentGossipMessage::try_from(bytes.as_ref())
@@ -319,7 +319,7 @@ mod tests {
     fn test_dkg_gossip_message() {
         let data = "arbitrary string".to_owned();
         let dkg = Dkg::new(data);
-        let message = DkgGossipMessage::new(dkg.clone());
+        let message = DkgGossipMessage::new(dkg);
 
         let bytes = message.to_bytes();
         let message_from_bytes = DkgGossipMessage::try_from(bytes.as_ref())
@@ -350,7 +350,7 @@ mod tests {
     #[test]
     fn test_dkg() {
         let data = "arbitrary string".to_owned();
-        let dkg = Dkg::new(data.clone());
+        let dkg = Dkg::new(data);
 
         let types_dkg: types::Dkg = dkg.clone().into();
         let dkg_from_types = Dkg::from(types_dkg);

--- a/wasm/vps/vp_user/src/lib.rs
+++ b/wasm/vps/vp_user/src/lib.rs
@@ -200,7 +200,7 @@ mod tests {
         init_vp_env(&mut env);
 
         let tx_data: Vec<u8> = vec![];
-        let addr: Address = env.addr.clone();
+        let addr: Address = env.addr;
         let keys_changed: HashSet<storage::Key> = HashSet::default();
         let verifiers: HashSet<Address> = HashSet::default();
 


### PR DESCRIPTION
In order to get good clippy linting on our unit tests, the --all-targets flag has been added to the clippy linting. This satisfies the request I made on Issue #57 (specifically [this](https://github.com/anomanetwork/anoma/issues/57#issuecomment-872435713))